### PR TITLE
fix malloc storage type for EL7

### DIFF
--- a/templates/el7/varnish-3.sysconfig.erb
+++ b/templates/el7/varnish-3.sysconfig.erb
@@ -7,7 +7,7 @@ VARNISH_ADMIN_LISTEN_ADDRESS=<%= scope['::varnish::admin_listen'] %>
 VARNISH_ADMIN_LISTEN_PORT=<%= scope['::varnish::admin_port'] %>
 VARNISH_SECRET_FILE=<%= scope['::varnish::secret_file'] %>
 <% if scope['::varnish::storage_type'] == 'malloc' -%>
-VARNISH_STORAGE_FILE=malloc
+VARNISH_STORAGE="malloc,<%= scope['::varnish::storage_size'] %>"
 <% elsif scope['::varnish::storage_type'] == 'file' -%>
 VARNISH_STORAGE="file,<%= scope['::varnish::storage_file'] %>,<%= scope['::varnish::storage_size'] %>"
 <% end -%>

--- a/templates/el7/varnish-4.sysconfig.erb
+++ b/templates/el7/varnish-4.sysconfig.erb
@@ -7,7 +7,7 @@ VARNISH_ADMIN_LISTEN_ADDRESS=<%= scope['::varnish::admin_listen'] %>
 VARNISH_ADMIN_LISTEN_PORT=<%= scope['::varnish::admin_port'] %>
 VARNISH_SECRET_FILE=<%= scope['::varnish::secret_file'] %>
 <% if scope['::varnish::storage_type'] == 'malloc' -%>
-VARNISH_STORAGE_FILE=malloc
+VARNISH_STORAGE="malloc,<%= scope['::varnish::storage_size'] %>"
 <% elsif scope['::varnish::storage_type'] == 'file' -%>
 VARNISH_STORAGE="file,<%= scope['::varnish::storage_file'] %>,<%= scope['::varnish::storage_size'] %>"
 <% end -%>


### PR DESCRIPTION
`VARNISH_STORAGE_FILE` isn't a valid parameter for the init script.  The `malloc` storage type should be using the same format as the `file` storage type (i.e. `VARNISH_STORAGE` instead of `VARNISH_STORAGE_FILE`).