### PR TITLE
Add support for Ubuntu (12.04)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,7 +108,7 @@ GEM
       net-http-pipeline
     hiera (1.3.4)
       json_pure
-    highline (1.7.0)
+    highline (1.7.1)
     inflecto (0.0.2)
     ipaddress (0.8.0)
     json (1.8.2)

--- a/README.markdown
+++ b/README.markdown
@@ -23,7 +23,7 @@ in a parameter.
 ## Module Description
 
 Supports:
- * Varnish 3 on EL6 and derivatives (RHEL, CentOS, OEL, Amazon Linux)
+ * Varnish 3 and 4 on EL6 and derivatives (RHEL, CentOS, OEL, Amazon Linux)
  * Varnish 3 on Ubuntu 12.04
  * Varnish 4 on EL7 and derivatives
 

--- a/README.markdown
+++ b/README.markdown
@@ -22,10 +22,10 @@ in a parameter.
 
 ## Module Description
 
-Supports Varnish 3 and Varnish 4 (4 only for EL7).
-
-Currently only working on EL derived distros
-(RHEL6/7, CentOS 6/7, OEL 6/7, Amazon Linux)
+Supports:
+ * Varnish 3 on EL6 and derivatives (RHEL, CentOS, OEL, Amazon Linux)
+ * Varnish 3 on Ubuntu 12.04
+ * Varnish 4 on EL7 and derivatives
 
 Requires Puppet >= 3.0
 
@@ -73,9 +73,6 @@ secret.
 
 
 ## Limitations
-
-Currently only working on EL derived distros
-(RHEL6/7, CentOS 6/7, OEL 6/7, Amazon Linux)
 
 ## Development
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,14 +4,7 @@
 #
 class varnish::config {
 
-  case $::varnish::varnish_version {
-    '3.0': {
-      $sysconfig_template = "varnish/el${::operatingsystemmajrelease}/varnish-3.sysconfig.erb"
-    }
-    default: {
-      $sysconfig_template = "varnish/el${::operatingsystemmajrelease}/varnish-4.sysconfig.erb"
-    }
-  }
+  $sysconfig_template = $::varnish::params::sysconfig_template
 
   file { $varnish::params::sysconfig:
     owner   => 'root',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,7 +4,28 @@
 #
 class varnish::config {
 
-  $sysconfig_template = $::varnish::params::sysconfig_template
+  case $::osfamily {
+    'RedHat', 'Amazon': {
+      case $::varnish::varnish_version {
+        '3.0': {
+          $sysconfig_template = "varnish/el${::operatingsystemmajrelease}/varnish-3.sysconfig.erb"
+        }
+        default: {
+          $sysconfig_template = "varnish/el${::operatingsystemmajrelease}/varnish-4.sysconfig.erb"
+        }
+      }
+    }
+    'Debian': {
+      case $::varnish::varnish_version {
+        '3.0': {
+          $sysconfig_template = 'varnish/debian/varnish-3.default.erb'
+        }
+        default: {
+          fail("Varnish version ${::varnish::varnish_version} not supported on ${::operatingsystem} (${::lsbdistdescription}, ${::lsbdistcodename})")
+        }
+      }
+    }
+  }
 
   file { $varnish::params::sysconfig:
     owner   => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,7 +36,7 @@
 #   Hash of runtime parameters
 #
 class varnish (
-  $addrepo         = true,
+  $addrepo         = $varnish::params::addrepo,
   $secret          = 'notsosecret',
   $secret_file     = $varnish::params::secret_file,
   $vcl_conf        = $varnish::params::vcl_conf,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,14 +18,12 @@ class varnish::params {
           $repoclass          = "varnish::repo::el${::operatingsystemmajrelease}"
           $sysconfig          = '/etc/sysconfig/varnish'
           $varnish_version    = '3.0'
-          $sysconfig_template = 'varnish/el6/varnish-3.sysconfig.erb'
         }
         '7': {
           $addrepo            = true
           $repoclass          = "varnish::repo::el${::operatingsystemmajrelease}"
           $sysconfig          = '/etc/varnish/varnish.params'
           $varnish_version    = '4.0'
-          $sysconfig_template = 'varnish/el7/varnish-4.sysconfig.erb'
         }
         default: {
           # Amazon Linux
@@ -33,7 +31,6 @@ class varnish::params {
           $repoclass          = "varnish::repo::el${::operatingsystemmajrelease}"
           $sysconfig          = '/etc/sysconfig/varnish'
           $varnish_version    = '3.0'
-          $sysconfig_template = 'varnish/el6/varnish-3.sysconfig.erb'
         }
       }
     }
@@ -43,7 +40,6 @@ class varnish::params {
           $addrepo            = false
           $sysconfig          = '/etc/default/varnish'
           $varnish_version    = '3.0'
-          $sysconfig_template = 'varnish/debian/varnish-3.default.erb'
           $vcl_reload         = '/usr/share/varnish/reload-vcl'
         }
         default: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,12 +47,12 @@ class varnish::params {
           $vcl_reload         = '/usr/share/varnish/reload-vcl'
         }
         default: {
-          fail("${::lsbdistdescription} (${::lsbdistcodename}) not supported")
+          fail("${::operatingsystem} (${::lsbdistdescription}, ${::lsbdistcodename}) not supported")
         }
       }
     }
     default: {
-      fail("${::lsbdistdescription} (${::lsbdistcodename}) not supported")
+      fail("${::operatingsystem} not supported")
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,32 +4,55 @@
 # It sets variables according to platform
 #
 class varnish::params {
+  
+  $package_name = 'varnish'
+  $service_name = 'varnish'
+  
   case $::osfamily {
     'RedHat', 'Amazon': {
-      $package_name = 'varnish'
-      $service_name = 'varnish'
       $vcl_reload   = '/usr/bin/varnish_reload_vcl'
+
       case $::operatingsystemmajrelease {
         '6': {
-          $repoclass       = "varnish::repo::el${::operatingsystemmajrelease}"
-          $sysconfig       = '/etc/sysconfig/varnish'
-          $varnish_version = '3.0'
+          $addrepo            = true
+          $repoclass          = "varnish::repo::el${::operatingsystemmajrelease}"
+          $sysconfig          = '/etc/sysconfig/varnish'
+          $varnish_version    = '3.0'
+          $sysconfig_template = 'varnish/el6/varnish-3.sysconfig.erb'
         }
         '7': {
-          $repoclass       = "varnish::repo::el${::operatingsystemmajrelease}"
-          $sysconfig       = '/etc/varnish/varnish.params'
-          $varnish_version = '4.0'
+          $addrepo            = true
+          $repoclass          = "varnish::repo::el${::operatingsystemmajrelease}"
+          $sysconfig          = '/etc/varnish/varnish.params'
+          $varnish_version    = '4.0'
+          $sysconfig_template = 'varnish/el7/varnish-4.sysconfig.erb'
         }
         default: {
           # Amazon Linux
-          $repoclass       = "varnish::repo::el${::operatingsystemmajrelease}"
-          $sysconfig       = '/etc/sysconfig/varnish'
-          $varnish_version = '3.0'
+          $addrepo            = true
+          $repoclass          = "varnish::repo::el${::operatingsystemmajrelease}"
+          $sysconfig          = '/etc/sysconfig/varnish'
+          $varnish_version    = '3.0'
+          $sysconfig_template = 'varnish/el6/varnish-3.sysconfig.erb'
+        }
+      }
+    }
+    'Debian': {
+      case $::lsbdistcodename {
+        'precise': {
+          $addrepo            = false
+          $sysconfig          = '/etc/default/varnish'
+          $varnish_version    = '3.0'
+          $sysconfig_template = 'varnish/debian/varnish-3.default.erb'
+          $vcl_reload         = '/usr/share/varnish/reload-vcl'
+        }
+        default: {
+          fail("${::lsbdistdescription} (${::lsbdistcodename}) not supported")
         }
       }
     }
     default: {
-      fail("${::operatingsystem} not supported")
+      fail("${::lsbdistdescription} (${::lsbdistcodename}) not supported")
     }
   }
 
@@ -48,3 +71,4 @@ class varnish::params {
   $storage_size   = '1G'
   $package_ensure = 'present'
 }
+

--- a/spec/classes/basic_spec.rb
+++ b/spec/classes/basic_spec.rb
@@ -46,6 +46,22 @@ describe 'varnish' do
       it { should contain_class('varnish::service').that_subscribes_to('varnish::config') }
 
     end
+    describe "varnish class with minimal parameters on Ubuntu 12.04" do
+      let(:params) {{
+        :secret => 'foobar'
+      }}
+      let (:facts) {{
+        :osfamily        => 'Debian',
+        :lsbdistcodename => 'precise',
+      }}
+
+      it { should compile.with_all_deps }
+      it { should contain_class('varnish::secret') }
+      it { should contain_class('varnish::install').that_comes_before('varnish::config') }
+      it { should contain_class('varnish::config') }
+      it { should contain_class('varnish::service').that_subscribes_to('varnish::config') }
+
+    end
   end
 
 

--- a/templates/debian/varnish-3.default.erb
+++ b/templates/debian/varnish-3.default.erb
@@ -1,0 +1,40 @@
+### This file created by Puppet, modification is probably futile
+
+# The Debian init script expects START, NFILES and MEMLOCK
+START=yes
+NFILES=131072
+MEMLOCK=82000
+
+RELOAD_VCL=1
+VARNISH_VCL_CONF=<%= scope['::varnish::vcl_conf'] %>
+VARNISH_LISTEN_ADDRESS=<%= scope['::varnish::listen'] %>
+VARNISH_LISTEN_PORT=<%= scope['::varnish::listen_port'] %>
+VARNISH_ADMIN_LISTEN_ADDRESS=<%= scope['::varnish::admin_listen'] %>
+VARNISH_ADMIN_LISTEN_PORT=<%= scope['::varnish::admin_port'] %>
+VARNISH_SECRET_FILE=<%= scope['::varnish::secret_file'] %>
+VARNISH_MIN_THREADS=<%= scope['::varnish::min_threads'] %>
+VARNISH_MAX_THREADS=<%= scope['::varnish::max_threads'] %>
+VARNISH_THREAD_TIMEOUT=<%= scope['::varnish::thread_timeout'] %>
+<% if scope['::varnish::storage_type'] == 'malloc' -%>
+VARNISH_STORAGE_FILE=malloc
+<% elsif scope['::varnish::storage_type'] == 'file' -%>
+VARNISH_STORAGE_FILE="file,<%= scope['::varnish::storage_file'] %>"
+<% end -%>
+VARNISH_STORAGE_SIZE=<%= scope['::varnish::storage_size'] %>
+VARNISH_STORAGE="${VARNISH_STORAGE_FILE},${VARNISH_STORAGE_SIZE}"
+VARNISH_USER=varnish
+VARNISH_GROUP=varnish
+VARNISH_TTL=120
+
+DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
+             -f ${VARNISH_VCL_CONF} \
+             -T ${VARNISH_ADMIN_LISTEN_ADDRESS}:${VARNISH_ADMIN_LISTEN_PORT} \
+             -t ${VARNISH_TTL} \
+             -w ${VARNISH_MIN_THREADS},${VARNISH_MAX_THREADS},${VARNISH_THREAD_TIMEOUT} \
+             -u ${VARNISH_USER} -g ${VARNISH_GROUP} \
+             -S ${VARNISH_SECRET_FILE} \
+             -s ${VARNISH_STORAGE}"
+<% scope['::varnish::runtime_params'].each do |k,v| -%>
+DAEMON_OPTS="${DAEMON_OPTS} -p <%= k %>=<%= v %>"
+<% end -%>
+


### PR DESCRIPTION
Added support for Ubuntu 12.04 by:
 * extending the params.pp with appropriate additional sections
 * controlling the defaulting of `addrepo` in params.pp
 * providing a config template for Varnish 3 suitable for Ubuntu. The init script requires additional vars that are passed to ulimit. The values are hard coded in the templated and lifted from the distribution default. There is room for further improvement here.
 * providing an additional rspec test
 * updating the README