### PR TITLE
Allow multiple VCLs to be created

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,6 +4,7 @@
 # It ensure the service is running
 #
 class varnish::service {
+  include varnish
   include varnish::params
 
   service { $varnish::params::service_name:
@@ -12,4 +13,11 @@ class varnish::service {
     hasstatus  => true,
     hasrestart => true,
   }
+  
+  # This exec resource receives notifications from varnish::vcl resources
+  exec { 'vcl_reload':
+    command     => $varnish::vcl_reload,
+    refreshonly => true,
+  }
+
 }

--- a/manifests/vcl.pp
+++ b/manifests/vcl.pp
@@ -10,17 +10,12 @@ define varnish::vcl (
   include varnish
   include varnish::params
 
-  exec { 'vcl_reload':
-    command     => $varnish::vcl_reload,
-    refreshonly => true,
-  }
-
   file { $file:
     content => $content,
-    notify  => Exec['vcl_reload'],
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
-    require => Class['varnish::service'],
+    require => Class['varnish::install'],
+    notify  => Exec['vcl_reload'],
   }
 }


### PR DESCRIPTION
Declaring more than one `varnish::vcl` will cause a duplicate resource error due to `Exec[vcl_reload]` being declared from within the `varnish::vcl` definition. This patch moves `Exec[vcl_reload]` into the `varnish::service` class.