### PR TITLE
Support Varnish 3 on Ubuntu 14.04

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -24,7 +24,7 @@ in a parameter.
 
 Supports:
  * Varnish 3 and 4 on EL6 and derivatives (RHEL, CentOS, OEL, Amazon Linux)
- * Varnish 3 on Ubuntu 12.04
+ * Varnish 3 on Ubuntu 12.04 and 14.04
  * Varnish 4 on EL7 and derivatives
 
 Requires Puppet >= 3.0

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,12 +36,11 @@ class varnish::params {
     }
     'Debian': {
       case $::lsbdistcodename {
-        'precise': {
+        'precise', 'trusty': {
           $addrepo            = false
           $sysconfig          = '/etc/default/varnish'
           $varnish_version    = '3.0'
           $vcl_reload         = '/usr/share/varnish/reload-vcl'
-
         }
         default: {
           fail("${::operatingsystem} (${::lsbdistdescription}, ${::lsbdistcodename}) not supported")

--- a/metadata.json
+++ b/metadata.json
@@ -41,7 +41,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "12.04"
+        "12.04",
+        "14.04"
       ]
     }
   ],


### PR DESCRIPTION
Varnish 3 hasn't changed much between Ubuntu 12.04 and 14.04. No additional logic needed; things work as-is.