### PR TITLE
Puppet 4 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,10 @@ source 'https://rubygems.org'
 group :test do
   gem 'rake'
   gem 'puppet-lint'
-  gem 'rspec-puppet', '~> 1.0.0'
+  gem 'rspec-puppet', '~> 2.2.0'
   gem 'rspec-system-puppet'
   gem 'puppetlabs_spec_helper'
-  gem 'puppet-syntax', '~> 1.2.0'
+  gem 'puppet-syntax', '~> 2.0.0'
   gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.7.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
       puppet (>= 2.7.16)
       rest-client
     puppet-lint (1.1.0)
-    puppet-syntax (1.2.3)
+    puppet-syntax (2.0.0)
       rake
     puppetlabs_spec_helper (0.8.2)
       mocha
@@ -170,7 +170,7 @@ GEM
     rspec-expectations (2.99.2)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.99.3)
-    rspec-puppet (1.0.1)
+    rspec-puppet (2.2.0)
       rspec
     rspec-system (2.8.0)
       fog (~> 1.18)
@@ -212,10 +212,10 @@ DEPENDENCIES
   puppet (~> 3.7.0)
   puppet-blacksmith
   puppet-lint
-  puppet-syntax (~> 1.2.0)
+  puppet-syntax (~> 2.0.0)
   puppetlabs_spec_helper
   rake
-  rspec-puppet (~> 1.0.0)
+  rspec-puppet (~> 2.2.0)
   rspec-system-puppet
   travis
   travis-lint

--- a/spec/classes/basic_spec.rb
+++ b/spec/classes/basic_spec.rb
@@ -91,7 +91,7 @@ describe 'varnish' do
         :operatingsystem => 'Nexenta',
       }}
 
-      it { expect { should }.to raise_error(Puppet::Error, /Nexenta not supported/) }
+      it { should raise_error(Puppet::Error, /Nexenta not supported/) }
     end
   end
 


### PR DESCRIPTION
Thought I'd see what was needed for Puppet 4 compatibility. Turns out, not much. The module is already 4.0 compliant but the newer version of rspec-puppet throws a warning.