### PR TITLE
Relax the dependency on puppetlabs/apt

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -63,7 +63,7 @@
     },
     {
     "name": "puppetlabs/apt",
-    "version_requirement": ">= 2.0.0"
+    "version_requirement": ">= 1.0.0"
     }
   ]
 }


### PR DESCRIPTION
The dependency on puppetlabs/apt >= 2.0.0 causes issues when using librarian-puppet or similar tools for dependency resolution.
Version 2.0.0 contains some (interface) breaking changes and for that reason a lot of other modules specify the dependency on puppetlabs/apt like < 2.0.0. 
This creates a conflict.

As the only declaration of functionality from puppetlabs/apt in this module is an apt::source definition, which is at least stable since version 1.0.0 of puppetlabs/apt, it would make sense to relax the requirement to this version.