### PR TITLE
Preseve order of keys when using each using .sort

### DIFF
--- a/templates/debian/varnish-3.default.erb
+++ b/templates/debian/varnish-3.default.erb
@@ -34,7 +34,7 @@ DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
              -u ${VARNISH_USER} -g ${VARNISH_GROUP} \
              -S ${VARNISH_SECRET_FILE} \
              -s ${VARNISH_STORAGE}"
-<% scope['::varnish::runtime_params'].each do |k,v| -%>
+<% scope['::varnish::runtime_params'].sort.each do |k,v| -%>
 DAEMON_OPTS="${DAEMON_OPTS} -p <%= k %>=<%= v %>"
 <% end -%>
 

--- a/templates/debian/varnish-4.default.erb
+++ b/templates/debian/varnish-4.default.erb
@@ -36,6 +36,6 @@ DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
              -u ${VARNISH_USER} -g ${VARNISH_GROUP} \
              -S ${VARNISH_SECRET_FILE} \
              -s ${VARNISH_STORAGE}"
-<% scope['::varnish::runtime_params'].each do |k,v| -%>
+<% scope['::varnish::runtime_params'].sort.each do |k,v| -%>
 DAEMON_OPTS="${DAEMON_OPTS} -p <%= k %>=<%= v %>"
 <% end -%>

--- a/templates/el6/varnish-3.sysconfig.erb
+++ b/templates/el6/varnish-3.sysconfig.erb
@@ -28,6 +28,6 @@ DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
              -u ${VARNISH_USER} -g ${VARNISH_GROUP} \
              -S ${VARNISH_SECRET_FILE} \
              -s ${VARNISH_STORAGE}"
-<% scope['::varnish::runtime_params'].each do |k,v| -%>
+<% scope['::varnish::runtime_params'].sort.each do |k,v| -%>
 DAEMON_OPTS="${DAEMON_OPTS} -p <%= k %>=<%= v %>"
 <% end -%>

--- a/templates/el6/varnish-4.sysconfig.erb
+++ b/templates/el6/varnish-4.sysconfig.erb
@@ -30,6 +30,6 @@ DAEMON_OPTS="-a ${VARNISH_LISTEN_ADDRESS}:${VARNISH_LISTEN_PORT} \
              -u ${VARNISH_USER} -g ${VARNISH_GROUP} \
              -S ${VARNISH_SECRET_FILE} \
              -s ${VARNISH_STORAGE}"
-<% scope['::varnish::runtime_params'].each do |k,v| -%>
+<% scope['::varnish::runtime_params'].sort.each do |k,v| -%>
 DAEMON_OPTS="${DAEMON_OPTS} -p <%= k %>=<%= v %>"
 <% end -%>

--- a/templates/el7/varnish-3.sysconfig.erb
+++ b/templates/el7/varnish-3.sysconfig.erb
@@ -15,6 +15,6 @@ VARNISH_USER=varnish
 VARNISH_GROUP=varnish
 VARNISH_TTL=120
 
-DAEMON_OPTS="<% scope['::varnish::runtime_params'].each do |k,v| -%>-p <%= k %>=<%= v %> \
+DAEMON_OPTS="<% scope['::varnish::runtime_params'].sort.each do |k,v| -%>-p <%= k %>=<%= v %> \
 <% end -%>
 -w <%= scope['::varnish::min_threads'] %>,<%= scope['::varnish::max_threads'] %>,<%= scope['::varnish::thread_timeout'] %>"

--- a/templates/el7/varnish-4.sysconfig.erb
+++ b/templates/el7/varnish-4.sysconfig.erb
@@ -15,7 +15,7 @@ VARNISH_USER=varnish
 VARNISH_GROUP=varnish
 VARNISH_TTL=120
 
-DAEMON_OPTS="<% scope['::varnish::runtime_params'].each do |k,v| -%>-p <%= k %>=<%= v %> \
+DAEMON_OPTS="<% scope['::varnish::runtime_params'].sort.each do |k,v| -%>-p <%= k %>=<%= v %> \
 <% end -%>
 -p thread_pool_min=<%= scope['::varnish::min_threads'] %> \
 -p thread_pool_max=<%= scope['::varnish::max_threads'] %> \


### PR DESCRIPTION
The contents of `/etc/sysconfig/varnish` (in CentOS) will change even when no values have been updated. Tracked this down to an issue running the module with ruby-1.8.7. Apparently the order of keys under 1.8.7 is inconsistent, causing the file to modified. 

Once the file is seen as changed, puppet will restart the varnish instance.

This quick fix, should preserve the order of keys when using runtime params so that the file contents do not change and puppet is restarted.

Tests passed before and after changes were made. 
