### PR TITLE
Add retry logic to the reload_vcl exec

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -17,6 +17,8 @@ class varnish::service {
   # This exec resource receives notifications from varnish::vcl resources
   exec { 'vcl_reload':
     command     => $varnish::vcl_reload,
+    tries       => 3,
+    try_sleep   => 3,
     refreshonly => true,
   }
 

--- a/spec/classes/basic_spec.rb
+++ b/spec/classes/basic_spec.rb
@@ -26,6 +26,12 @@ describe 'varnish' do
         .with_content("foobar\n") }
       it { should contain_file('/etc/sysconfig/varnish') }
       it { should contain_service('varnish') }
+      it { should contain_exec('vcl_reload').with({
+        'command'   => '/usr/bin/varnish_reload_vcl',
+        'tries'     => 3,
+        'try_sleep' => 3,
+        'refreshonly' => true
+      })}
     end
     describe "varnish class with minimal parameters on RedHat 7" do
       let(:params) {{
@@ -44,6 +50,12 @@ describe 'varnish' do
       it { should contain_class('varnish::install').that_comes_before('varnish::config') }
       it { should contain_class('varnish::config') }
       it { should contain_class('varnish::service').that_subscribes_to('varnish::config') }
+      it { should contain_exec('vcl_reload').with({
+        'command'   => '/usr/sbin/varnish_reload_vcl',
+        'tries'     => 3,
+        'try_sleep' => 3,
+        'refreshonly' => true
+      })}
 
     end
     describe "varnish class with minimal parameters on Ubuntu 12.04" do
@@ -60,6 +72,12 @@ describe 'varnish' do
       it { should contain_class('varnish::install').that_comes_before('varnish::config') }
       it { should contain_class('varnish::config') }
       it { should contain_class('varnish::service').that_subscribes_to('varnish::config') }
+      it { should contain_exec('vcl_reload').with({
+        'command'   => '/usr/share/varnish/reload-vcl',
+        'tries'     => 3,
+        'try_sleep' => 3,
+        'refreshonly' => true
+      })}
 
     end
 
@@ -79,6 +97,12 @@ describe 'varnish' do
       it { should contain_class('varnish::install').that_comes_before('varnish::config') }
       it { should contain_class('varnish::config') }
       it { should contain_class('varnish::service').that_subscribes_to('varnish::config') }
+      it { should contain_exec('vcl_reload').with({
+        'command'   => '/usr/share/varnish/reload-vcl',
+        'tries'     => 3,
+        'try_sleep' => 3,
+        'refreshonly' => true
+      })}
 
     end
 
@@ -98,6 +122,12 @@ describe 'varnish' do
       it { should contain_class('varnish::install').that_comes_before('varnish::config') }
       it { should contain_class('varnish::config') }
       it { should contain_class('varnish::service').that_subscribes_to('varnish::config') }
+      it { should contain_exec('vcl_reload').with({
+        'command'   => '/usr/share/varnish/reload-vcl',
+        'tries'     => 3,
+        'try_sleep' => 3,
+        'refreshonly' => true
+      })}
 
     end
 
@@ -117,6 +147,12 @@ describe 'varnish' do
       it { should contain_class('varnish::install').that_comes_before('varnish::config') }
       it { should contain_class('varnish::config') }
       it { should contain_class('varnish::service').that_subscribes_to('varnish::config') }
+      it { should contain_exec('vcl_reload').with({
+        'command'   => '/usr/share/varnish/reload-vcl',
+        'tries'     => 3,
+        'try_sleep' => 3,
+        'refreshonly' => true
+      })}
 
     end
   end


### PR DESCRIPTION
Hi,

We've occasionally seen the `reload_vcl` exec fail, couldn't get to the bottom of exactly why, but it's possibly because we're using `consul_template` to manage the backends, and the backend.vcl isn't populated at that time.

This change adds a retry mechanism, which appears to fix the problem for us.

Thanks,
Andrew
