### PR TITLE
Allow varnish 4.1 support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,7 +68,7 @@ class varnish (
   unless is_integer($max_threads) { fail('max_threads invalid') }
   validate_absolute_path($storage_file)
   validate_hash($runtime_params)
-  validate_re($varnish_version, '^[3-4]\.0')
+  validate_re($varnish_version, '^[3-4]\.[0-1]')
   validate_re($storage_type, '^(malloc|file)$')
 
   if ($addrepo) {


### PR DESCRIPTION
Allows the option to add the varnish 4.1 repository, currently the regex check doesn't allow for it