### PR TITLE
Add support for 6 in params.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -96,7 +96,7 @@ class varnish (
   validate_absolute_path($storage_file)
   validate_hash($runtime_params)
   validate_re($storage_type, '^(malloc|file)$')
-  validate_re("${version_major}.${version_minor}", '^[3-5]\.[0-9]')
+  validate_re("${version_major}.${version_minor}", '^[3-6]\.[0-9]')
 
   if $addrepo {
     class { '::varnish::repo':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,6 +25,7 @@ class varnish::params {
         '7': {
           $os_service_provider = 'systemd'
           $vcl_reload          = $::varnish::version_major ? {
+            '6' => '/usr/sbin/varnishreload',
             '5' => '/sbin/varnish_reload_vcl',
             '4' => '/usr/sbin/varnish_reload_vcl',
             '3' => '/usr/bin/varnish_reload_vcl',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,6 +15,7 @@ class varnish::params {
         '6': {
           $os_service_provider = 'sysvinit'
           $vcl_reload          = $::varnish::version_major ? {
+            '6' => '/usr/sbin/varnishreload',
             '5' => '/usr/sbin/varnish_reload_vcl',
             '4' => '/usr/sbin/varnish_reload_vcl',
             '3' => '/usr/bin/varnish_reload_vcl',


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
I'm trying to shoehorn varnish6-support into the puppet3-branch.

Cherry-picking 170214cdde6c2f96866a89a08d598b4ee4fb6123 and e98b9fcb, plus changed 5 into 6 in the regexp covering allowable versions.

(We do use centos7 with puppet3.  The README states that varnish6 is not supported on centos7, though I'd like to give it a shot.  I'll choose Ubuntu 18.04 and Puppet5 if I have to)