### PR TITLE
Allow newer versions of apt dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.0.0 < 5.0.0"
+      "version_requirement": ">= 2.0.0 < 9.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
Fix #62

#### Pull Request (PR) description
We've been using this module with puppetlabs/apt v 8.3.0 for quite long without issues

#### This Pull Request (PR) fixes the following issues
Fixes #62